### PR TITLE
Video component does not replace original div. 

### DIFF
--- a/src/video.jsx
+++ b/src/video.jsx
@@ -89,6 +89,10 @@ function Video({ videoUrl, alt }) {
       <Video videoUrl={img.src} alt={img.alt} />,
       root
     );
-    div.parentElement.replaceChild(root, div);
+    div.classList.remove("admonition", "video");
+    for (const child of div.children) {
+      div.removeChild(child);
+    }
+    div.appendChild(root);
   });
 }


### PR DESCRIPTION
Now it  replaces all its children. This should fix a bug where video components were shown incorrectly after an unclicked progress button.