### PR TITLE
pdf plugin

### DIFF
--- a/src/pdf.jsx
+++ b/src/pdf.jsx
@@ -1,0 +1,59 @@
+import React from "react";
+import ReactDOM from "react-dom";
+import styled from "styled-components";
+
+
+const PdfWrapper = styled.div`
+display: flex;
+justify-content: center;
+align-items: center;
+
+& > .print-description {
+  display: none;
+}
+
+@media print {
+  & iframe {
+    display: none;
+  }
+  & video {
+    display: none;
+  }
+
+  & > .print-description {
+    display: block;
+  }
+}
+`;
+
+
+function Pdf({ source }) {
+
+    return (
+        <PdfWrapper>
+            <embed
+                src={source}
+                type="application/pdf"
+                height={300}
+                width="80%"
+            />
+        </PdfWrapper>
+    );
+}
+
+{
+    const documentPdfTags = document.querySelectorAll('.admonition.pdf');
+    documentPdfTags.forEach((div) => {
+        const source = div.getElementsByTagName('img')[0];
+        const root = document.createElement('div');
+        ReactDOM.render(
+            <Pdf source={source.src} />,
+            root
+        );
+        div.classList.remove("admonition", "pdf");
+        for (const child of div.children) {
+            div.removeChild(child);
+        }
+        div.appendChild(root);
+    });
+}

--- a/src/plugin-bundle.js
+++ b/src/plugin-bundle.js
@@ -12,3 +12,4 @@ import "./slides";
 import "./notify-content-update";
 import "./submission-list";
 import "./image-enlacer";
+import "./pdf"


### PR DESCRIPTION
```
!!! pdf
    ![](sample.pdf)
```

Plugin simples que facilita o uso de pdfs (em embarcados eu tenho que usar bastante), talvez uma segunda versão que possibilitasse exibir apenas uma página específica fosse útil. 

A impressão fica uma merda... qual será que é a melhor forma? Colocar um QR code como no vídeo (que faz o download do doc) ? Exibir apenas a primeira página? 

![image](https://user-images.githubusercontent.com/1039615/171770231-c5ece912-a482-49c9-8f33-019eecadbaba.png)
